### PR TITLE
Fix proposal for issue 1

### DIFF
--- a/Polyline/Polyline.swift
+++ b/Polyline/Polyline.swift
@@ -101,11 +101,11 @@ public class Polyline {
     }
     
     private func encodeSingleCoordinate(value : Double) -> String {
-        let e5Value = value * 1e5
-        var intValue = Int(round(e5Value))
+        let roundedE5Value = round(value * 1e5)
+        var intValue = Int(roundedE5Value)
         intValue = intValue << 1
         
-        if value < 0 {
+        if roundedE5Value < 0 {
             intValue = ~intValue
         }
         var fiveBitComponent = 0

--- a/PolylineTests/PolylineTests.swift
+++ b/PolylineTests/PolylineTests.swift
@@ -54,6 +54,16 @@ class PolylineTests: XCTestCase {
         XCTAssertEqual(sut.encodedPolyline,"_p~iF~ps|U_ulLnnqC_mqNvxq`@")
     }
     
+    // Github issue 1
+    func testSmallNegativeDifferencesShouldBeEncodedProperly() {
+        var locations = [CLLocation(latitude: 37.32721043, longitude: 122.02685069),
+            CLLocation(latitude: 37.32727259, longitude: 122.02685280),
+            CLLocation(latitude: 37.32733398, longitude: 122.02684998)]
+        
+        let sut = Polyline(locations: locations)
+        XCTAssertEqual(sut.encodedPolyline, "anybFyjxgVK?K?")
+    }
+    
     // MARK: - Decoding locations
     
     func testEmptyPolylineShouldBeEmptyLocationArray() {


### PR DESCRIPTION
Small negative differences were causing an infinite loop.
Because the rounded value was 0, but when checking for negativity
we used the original negative value.
