### PR TITLE
Set BITCODE_GENERATION_MODE

### DIFF
--- a/Polyline.xcodeproj/project.pbxproj
+++ b/Polyline.xcodeproj/project.pbxproj
@@ -549,6 +549,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -600,6 +601,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
This PR sets the `BITCODE_GENERATION_MODE` build setting. Without it, downstream Xcode projects that require Bitcode fail to link with the following error when archiving:

```
❌ ld: bitcode bundle could not be generated because '/Users/vagrant/Library/Developer/Xcode/DerivedData/MapboxDirections-gbbqahomsobhupaidxupgypftlrd/Build/Products/Debug-watchos/Polyline-watchOS/Polyline.framework/Polyline' was built without full bitcode. All frameworks and dylibs for bitcode must be generated from Xcode Archive or Install build for architecture armv7k
```

/cc @tomtaylor @boundsj