### PR TITLE
Omit mkPolyline from tvOS 8, watchOS builds

### DIFF
--- a/Polyline/Polyline.swift
+++ b/Polyline/Polyline.swift
@@ -55,12 +55,15 @@ public struct Polyline {
         return self.coordinates.map(toLocations)
     }
     
+    #if !os(watchOS)
     // Convert polyline to MKPolyline to use with MapKit (nil if polyline cannot be decoded)
+    @available(tvOS 9.2, *)
     public var mkPolyline: MKPolyline? {
         guard let coordinates = self.coordinates else { return nil }
         let mkPolyline = MKPolyline(coordinates: coordinates, count: coordinates.count)
         return mkPolyline
     }
+    #endif
     
     // MARK: - Public Methods -
     

--- a/Polyline/Polyline.swift
+++ b/Polyline/Polyline.swift
@@ -56,7 +56,7 @@ public struct Polyline {
     }
     
     #if !os(watchOS)
-    // Convert polyline to MKPolyline to use with MapKit (nil if polyline cannot be decoded)
+    /// Convert polyline to MKPolyline to use with MapKit (nil if polyline cannot be decoded)
     @available(tvOS 9.2, *)
     public var mkPolyline: MKPolyline? {
         guard let coordinates = self.coordinates else { return nil }

--- a/PolylineTests/PolylineTests.swift
+++ b/PolylineTests/PolylineTests.swift
@@ -347,6 +347,7 @@ class PolylineTests:XCTestCase {
         let _ = Polyline(encodedPolyline: "ak{hRak{hR", precision: 1e6)
     }
     
+    @available(tvOS 9.2, *)
     func testPolylineConvertionToMKPolyline() {
         let polyline = Polyline(encodedPolyline: "qkqtFbn_Vui`Xu`l]")
         
@@ -355,12 +356,14 @@ class PolylineTests:XCTestCase {
         XCTAssertTrue(polyline.coordinates?.count == mkPolyline?.pointCount)
     }
     
+    @available(tvOS 9.2, *)
     func testPolylineConvertionToMKPolylineWhenEncodingFailed() {
         let polyline = Polyline(encodedPolyline: "invalidPolylineString")
         let mkPolyline = polyline.mkPolyline
         XCTAssertNil(mkPolyline)
     }
     
+    @available(tvOS 9.2, *)
     func testEmptyPolylineConvertionShouldBeEmptyMKPolyline() {
         let polyline = Polyline(encodedPolyline: "")
         let mkPolyline = polyline.mkPolyline


### PR DESCRIPTION
Fixed the following compilation errors on tvOS and watchOS introduced by #39:

```
/path/to/Polyline/Polyline/Polyline.swift
/path/to/Polyline/Polyline/Polyline.swift:59:28: 'MKPolyline' is only available on tvOS 9.2 or newer
/path/to/Polyline/Polyline/Polyline.swift:59:28: Add @available attribute to enclosing var
/path/to/Polyline/Polyline/Polyline.swift:59:28: Add @available attribute to enclosing struct
/path/to/Polyline/Polyline/Polyline.swift:61:26: 'MKPolyline' is only available on tvOS 9.2 or newer
/path/to/Polyline/Polyline/Polyline.swift:61:26: Add 'if #available' version check
/path/to/Polyline/Polyline/Polyline.swift:61:26: Add @available attribute to enclosing var
/path/to/Polyline/Polyline/Polyline.swift:61:26: Add @available attribute to enclosing struct
```

```
/path/to/Polyline/Polyline/Polyline.swift
/path/to/Polyline/Polyline/Polyline.swift:59:28: Use of undeclared type 'MKPolyline'
/path/to/Polyline/Polyline/Polyline.swift:61:26: Use of unresolved identifier 'MKPolyline'
/path/to/Polyline/Polyline/Polyline.swift:59:16: Did you mean 'mkPolyline'?
/path/to/Polyline/Polyline/Polyline.swift:41:15: Did you mean 'Polyline'?
```

/cc @tomtaylor @frederoni