### PR TITLE
Have Travis test on macOS, tvOS, watchOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8
+osx_image: xcode8.2
 before_script:
   - export LANG=en_US.UTF-8
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,9 @@ osx_image: xcode8.2
 before_script:
   - export LANG=en_US.UTF-8
 script:
-  - xcodebuild -project Polyline.xcodeproj -scheme Polyline -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO
-  - xcodebuild test -project Polyline.xcodeproj -scheme Polyline -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.0' ONLY_ACTIVE_ARCH=NO
+  - xcodebuild $ACTION -project Polyline.xcodeproj -scheme "$SCHEME" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO
+env:
+  - SCHEME=Polyline ACTION=test DESTINATION='platform=iOS Simulator,name=iPhone 7,OS=10.1' ONLY_ACTIVE_ARCH=NO
+  - SCHEME=PolylineMac ACTION=test DESTINATION='platform=OS X'
+  - SCHEME=PolylineTV ACTION=test DESTINATION='platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1'
+  - SCHEME=PolylineWatch ACTION=build DESTINATION='platform=watchOS Simulator,name=Apple Watch Series 2 - 42mm,OS=3.1'


### PR DESCRIPTION
Upgraded to Xcode 8.2. Added a build matrix to test the library on iOS, macOS, and tvOS in tandem, and also build on watchOS. (There isn’t a watchOS test target.)