### PR TITLE
Only use app extension safe API calls

### DIFF
--- a/Polyline.xcodeproj/project.pbxproj
+++ b/Polyline.xcodeproj/project.pbxproj
@@ -677,6 +677,7 @@
 		207F641219B5DF7E005261FA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -698,6 +699,7 @@
 		207F641319B5DF7E005261FA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
We are using `Polyline` in one of our frameworks which in return is used in our app extensions.

With these changes the compiler won't complain about linking to not safe dylibs (full error message: `linking against a dylib which is not safe for use in application extensions`).

These changes only affect the iOS target.