### PR TITLE
Fix watchOS compiler error about MapKit

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     xcodebuild $ACTION -project Polyline.xcodeproj -scheme "$SCHEME" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO
     swift build

--- a/Sources/Polyline/Polyline.swift
+++ b/Sources/Polyline/Polyline.swift
@@ -24,7 +24,7 @@ import Foundation
 #if canImport(CoreLocation)
 import CoreLocation
 #endif
-#if canImport(MapKit)
+#if canImport(MapKit) && !os(watchOS)
 import MapKit
 #endif
 
@@ -61,7 +61,7 @@ public struct Polyline {
     }
     #endif
     
-    #if canImport(MapKit)
+    #if canImport(MapKit) && !os(watchOS)
     /// Convert polyline to MKPolyline to use with MapKit (nil if polyline cannot be decoded)
     @available(tvOS 9.2, *)
     public var mkPolyline: MKPolyline? {


### PR DESCRIPTION
Fixed a compiler error on watchOS due to usage of MapKit, which is unavailable on that platform: https://github.com/raphaelmor/Polyline/pull/55#discussion_r517745198. This compiler error wasn’t caught by CI because the #55 added a shell script that didn’t propagate its commands’ errors. This change hooks up the script so that any failure in `xcodebuild` or `swift` will cause the build to fail.

/cc @frederoni @MaximAlien