### PR TITLE
Make CLLocationCoordinate2D properties public on Linux

### DIFF
--- a/Sources/Polyline/CoreLocation.swift
+++ b/Sources/Polyline/CoreLocation.swift
@@ -37,8 +37,8 @@ public typealias LocationCoordinate2D = CLLocationCoordinate2D
  A geographic coordinate.
  */
 public struct LocationCoordinate2D {
-    let latitude: Double
-    let longitude: Double
+    public let latitude: Double
+    public let longitude: Double
     
     public init(latitude: Double, longitude: Double) {
         self.latitude = latitude


### PR DESCRIPTION
The `CLLocationCoordinate2D` compatibility shim added in #55 declares the `latitude` and `longitude` properties as internal on Linux, so clients can’t really use this type. This PR makes them public.

/ref https://github.com/mapbox/turf-swift/issues/119#issuecomment-722648354
/cc @MaximAlien @frederoni