### PR TITLE
Modernize buffer access

### DIFF
--- a/Tests/PolylineTests/FunctionalPolylineTests.swift
+++ b/Tests/PolylineTests/FunctionalPolylineTests.swift
@@ -182,4 +182,13 @@ class FunctionalPolylineTests : XCTestCase {
         #endif
     }
     
+    func testDecodingPolyline() {
+        let coordinates = decodePolyline("afvnFdrebO@o@", precision: 1e5) as [LocationCoordinate2D]?
+        XCTAssertNotNil(coordinates)
+        XCTAssertEqual(coordinates?.count, 2)
+        XCTAssertEqual(coordinates?.first?.latitude ?? 0.0, 39.27665, accuracy: 1e-5)
+        XCTAssertEqual(coordinates?.first?.longitude ?? 0.0, -84.411389, accuracy: 1e-5)
+        XCTAssertEqual(coordinates?.last?.latitude ?? 0.0, 39.276635, accuracy: 1e-5)
+        XCTAssertEqual(coordinates?.last?.longitude ?? 0.0, -84.411148, accuracy: 1e-5)
+    }
 }

--- a/Tests/PolylineTests/XCTestManifests.swift
+++ b/Tests/PolylineTests/XCTestManifests.swift
@@ -7,6 +7,7 @@ extension FunctionalPolylineTests {
     // to regenerate.
     static let __allTests__FunctionalPolylineTests = [
         ("testAnotherValidPolylineShouldReturnValidLocationArray", testAnotherValidPolylineShouldReturnValidLocationArray),
+        ("testDecodingPolyline", testDecodingPolyline),
         ("testEmptyArrayShouldBeEmptyString", testEmptyArrayShouldBeEmptyString),
         ("testEmptyLevelsShouldBeEmptyLevelArray", testEmptyLevelsShouldBeEmptyLevelArray),
         ("testEmptylevelsShouldBeEmptyString", testEmptylevelsShouldBeEmptyString),


### PR DESCRIPTION
#43 fixed a Swift compiler warning about unsafely casting a buffer in memory by reinterpreting the data as an NSData, which has fewer safety checks. We got lucky until adding support for Linux in #55: on some systems, the string is stored in a format that’s inconsistent with NSData’s internal storage on Apple platforms. This resulted in undefined behavior and random crashes on Linux when calling `decodePolyline(_:precision:)`. As of Swift 5, the safer way to get random access into this buffer appears to be `Data.withUnsafeBytes(_:)` and casting later.

/cc @frederoni @MaximAlien @erichoracek