### PR TITLE
Bump Package.swift tools versions to match supported Swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Otherwise, Xcode 13 will show a warning: upgrade to Swift 5. 
Polyline already declares Swift 5.0 as a requirement.