### PR TITLE
v5.1.0

### DIFF
--- a/Polyline.podspec
+++ b/Polyline.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "Polyline"
-  s.version      = "5.0.4"
+  s.version      = "5.1.0"
   s.summary      = "Polyline encoder / decoder in swift"
 
   s.description  = <<-DESC

--- a/Sources/Polyline/Info.plist
+++ b/Sources/Polyline/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.4</string>
+	<string>5.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/PolylineTests/Info.plist
+++ b/Tests/PolylineTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.4</string>
+	<string>5.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
After merging #79, I realized that increasing the minimum deployment target is a bigger deal than what normally goes into patch releases, so this PR replaces v5.0.4 with v5.1.0.

/cc @MaximAlien